### PR TITLE
Fix null attribute values output

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const BOOLEAN_ATTRIBUTES = [
 ];
 
 function escape(unsafe) {
+  if (unsafe === null) return '';
+
   return String(unsafe)
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')

--- a/test/html.js
+++ b/test/html.js
@@ -37,6 +37,11 @@ describe('HTML Builder', function () {
       assert.equal(h('div', { test: undefined, t: '1' })({ test: 'bla' }), '<div t="1"></div>');
     });
 
+    it('should treat nulls as empty strings', function() {
+      const empty = { id: null, name: null };
+      assert.equal(h('option', { value: G('id') }, G('name'))(empty), '<option value=""></option>');
+    });
+
     it('should render boolean attributes if value is true', function () {
       assert.equal(h('div', { readonly: true } )(), '<div readonly></div>');
       assert.equal(h('div', { readonly: G('readonly') } )({ readonly: true }), '<div readonly></div>');


### PR DESCRIPTION
When rendering an `option` tag with `null`  value, the result should be `<option value='' />` and not `<option value='null' />`