### PR TITLE
Fix nested array serialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,13 +80,15 @@ function html(tagDescription, ...data) {
 }
 
 function renderComplexObject(obj, context) {
-  const level = { ...obj };
+  const renderVal = val => (typeof val === 'object')
+    ?  renderComplexObject(val, context)
+    : renderWith(val, context);
 
-  forEachKey(obj, (key, val) => {
-    level[key] = typeof val === 'object'
-      ? renderComplexObject(val, context)
-      : renderWith(val, context);
-  });
+  if (Array.isArray(obj)) return obj.map(renderVal);
+
+  const level = { };
+
+  forEachKey(obj, (key, val) => (level[key] = renderVal(val)));
 
   return level;
 }

--- a/test/html.js
+++ b/test/html.js
@@ -74,6 +74,7 @@ describe('HTML Builder', function () {
 
     it('should render deep objects in attributes', function () {
       assert.equal(h('div', { data: { data: { id: G('id') } } })({ id: 1 }), '<div data="{&quot;data&quot;:{&quot;id&quot;:1}}"></div>');
+      assert.equal(h('div', { data: { list: [1, 2, 3] } })(), '<div data="{&quot;list&quot;:[1,2,3]}"></div>');
     });
 
     it('should escape html strings', function () {


### PR DESCRIPTION
Исправляет регрессию, когда массивы в атрибутах рендерятся как объекты:
`{"0": { ... }, "1": { ... }, ... }`